### PR TITLE
Removed un-required attributes from <link> and <script> tags

### DIFF
--- a/lib/sinatra/assetpack/package.rb
+++ b/lib/sinatra/assetpack/package.rb
@@ -106,9 +106,9 @@ module Sinatra
     private
       def link_tag(file, options={})
         if js?
-          "<script type='text/javascript' src='#{e file}'#{kv options}></script>"
+          "<script src='#{e file}'#{kv options}></script>"
         elsif css?
-          "<link rel='stylesheet' type='text/css' href='#{e file}'#{kv options} />"
+          "<link rel='stylesheet' href='#{e file}'#{kv options} />"
         end
       end
     end

--- a/test/unit_test.rb
+++ b/test/unit_test.rb
@@ -62,14 +62,14 @@ class AppTest < UnitTest
 
   test "helpers" do
     get '/index.html'
-    assert body =~ /<script type='text\/javascript' src='\/js\/hello.[0-9]+.js'><\/script>/
-    assert body =~ /<script type='text\/javascript' src='\/js\/hi.[0-9]+.js'><\/script>/
+    assert body =~ /<script src='\/js\/hello.[0-9]+.js'><\/script>/
+    assert body =~ /<script src='\/js\/hi.[0-9]+.js'><\/script>/
   end
 
   test "helpers in production (compressed html thingie)" do
     app.expects(:production?).returns(true)
     get '/index.html'
-    assert body =~ /<script type='text\/javascript' src='\/js\/app.[0-9]+.js'><\/script>/
+    assert body =~ /<script src='\/js\/app.[0-9]+.js'><\/script>/
   end
 
   test "compressed js" do
@@ -96,6 +96,6 @@ class AppTest < UnitTest
 
   test "helpers css" do
     get '/helpers/css'
-    assert body =~ %r{link rel='stylesheet' type='text/css' href='/css/screen.[0-9]+.css' media='screen'}
+    assert body =~ %r{link rel='stylesheet' href='/css/screen.[0-9]+.css' media='screen'}
   end
 end


### PR DESCRIPTION
I noticed that these attributes were present in the output created from sinatra-assetpack—

Here is a quick (and tested) patch to remove them. 
