### PR TITLE
Use the more ubiquitous 'file' utility instead of the 'identify' utility 

### DIFF
--- a/lib/sinatra/assetpack/image.rb
+++ b/lib/sinatra/assetpack/image.rb
@@ -30,8 +30,8 @@ module Sinatra
       def dimensions
         return @dimensions  unless @dimensions.nil?
 
-         _, _, dim = `identify "#{@file}"`.split(' ')
-         w, h = dim.split('x')
+        dim = /(\d+) x (\d+)/.match(`file "#{@file}"`)
+        w, h = dim[1,2]
 
          if w.to_i != 0 && h.to_i != 0
            @dimensions = [w.to_i, h.to_i]


### PR DESCRIPTION
This patch makes use of the 'file' utility for determining image dimensions instead of the 'identify' utility. 'file' comes preinstalled on more systems (including Mac OS).
