### PR TITLE
Require Sinatra::Base explicitly

### DIFF
--- a/lib/sinatra/assetpack.rb
+++ b/lib/sinatra/assetpack.rb
@@ -1,4 +1,5 @@
 require 'rack/test'
+require 'sinatra/base'
 
 module Sinatra
   module AssetPack


### PR DESCRIPTION
When using this project with Nesta, I encountered the following errors:

  ERROR -- : undefined method `register' for Sinatra:Module (NoMethodError)
  /usr/local/rvm/gems/ruby-1.9.3-p0@tblog/gems/sinatra-assetpack-0.0.11/lib/sinatra/assetpack.rb:60:in`module:Sinatra'
  /usr/local/rvm/gems/ruby-1.9.3-p0@tblog/gems/sinatra-assetpack-0.0.11/lib/sinatra/assetpack.rb:3:in `<top (required)>'
  /usr/local/rvm/gems/ruby-1.9.3-p0@tblog/gems/bundler-1.1.1/lib/bundler/runtime.rb:68:in`require'
  /usr/local/rvm/gems/ruby-1.9.3-p0@tblog/gems/bundler-1.1.1/lib/bundler/runtime.rb:68:in `block (2 levels) in require'
  /usr/local/rvm/gems/ruby-1.9.3-p0@tblog/gems/bundler-1.1.1/lib/bundler/runtime.rb:66:in`each'
  /usr/local/rvm/gems/ruby-1.9.3-p0@tblog/gems/bundler-1.1.1/lib/bundler/runtime.rb:66:in `block in require'
  /usr/local/rvm/gems/ruby-1.9.3-p0@tblog/gems/bundler-1.1.1/lib/bundler/runtime.rb:55:in`each'
  /usr/local/rvm/gems/ruby-1.9.3-p0@tblog/gems/bundler-1.1.1/lib/bundler/runtime.rb:55:in `require'
  /usr/local/rvm/gems/ruby-1.9.3-p0@tblog/gems/bundler-1.1.1/lib/bundler.rb:119:in`require'
  config.ru:5:in `block in <main>'
  /usr/local/rvm/gems/ruby-1.9.3-p0@tblog/gems/rack-1.4.1/lib/rack/builder.rb:51:in`instance_eval'
  /usr/local/rvm/gems/ruby-1.9.3-p0@tblog/gems/rack-1.4.1/lib/rack/builder.rb:51:in `initialize'
  config.ru:1:in`new'
  config.ru:1:in `<main>'

This commit resolves that issue.
