### PR TITLE
Character encoding wrangling doesn't work in Ruby 1.8. Bypass if not supported.

### DIFF
--- a/lib/sinatra/assetpack/package.rb
+++ b/lib/sinatra/assetpack/package.rb
@@ -96,9 +96,12 @@ module Sinatra
         session = Rack::Test::Session.new(@assets.app)
         paths.map { |path|
           result = session.get(path)
-          response_encoding = result.content_type.split(/;\s*charset\s*=\s*/).last.upcase rescue 'ASCII-8BIT'
-          # p [:combined, path, result.body.encoding.name, response_encoding]
-          result.body.force_encoding(response_encoding).encode(Encoding.default_external || 'ASCII-8BIT')  if result.status == 200
+          if result.body.respond_to?(:force_encoding)
+            response_encoding = result.content_type.split(/;\s*charset\s*=\s*/).last.upcase rescue 'ASCII-8BIT'
+            result.body.force_encoding(response_encoding).encode(Encoding.default_external || 'ASCII-8BIT')  if result.status == 200
+          else
+            result.body  if result.status == 200
+          end
         }.join("\n")
       end
 


### PR DESCRIPTION
Strings don't have force_encoding and the Encoding class doesn't exist. Added a little respond_to? check around the call. 
