### PR TITLE
README intro needs to mention `js :app` when saying 'Use this instead of messy script tags'

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ render Sass or whatever. No-siree!
    * JavaScript/CoffeeScript files in `/app/js`
    * CSS/Sass/Less/CSS files in `/app/css`
    * Images into `/app/images`
-3. Add `register Sinatra::AssetPack` and set up options to your app (see below)
-4. Use `<%= css :application %>` to your layouts. Use this instead of
-   messy *script* and *link* tags
+3. Add `register Sinatra::AssetPack` and set up options to your app (see below).
+4. Use `<%= js :app %>` and `<%= css :application %>` to your layouts. Use these instead of
+   messy *script* and *link* tags.
 5. BOOM! You're in business baby!
 
 Installation


### PR DESCRIPTION
The intro mentions using '<%= css :application %>' in layout, and to use this instead of messy script and link tags. It should actually mention how to pack javascript as well. Quite a minor issue, and it should be obvious to everyone that css :application doesn't actually pack javascripts as well, but better to be technically accurate anyway. :)
