### PR TITLE
Added option to include full domain name for js, css, and image files

### DIFF
--- a/examples/basic/app.rb
+++ b/examples/basic/app.rb
@@ -26,7 +26,13 @@ class App < Sinatra::Base
       '/css/more/*.css'
     ]
 
-    prebuild true
+    prebuild false
+
+    # Can set this as an environment variable like "HOST" or "CDN_HOST"
+    # This will add the domain name to the beginning of compiled assets
+    # Useful if you need to serve production assets from a CDN
+    host_name 'http://localhost:4567'
+
   end
 
   get '/' do

--- a/lib/sinatra/assetpack/css.rb
+++ b/lib/sinatra/assetpack/css.rb
@@ -11,7 +11,11 @@ module Sinatra
             if options.to_s.include?('embed')
               to_data_uri(local)
             else
-              BusterHelpers.add_cache_buster(file, local)
+              unless assets.host_name.nil?
+                assets.host_name+BusterHelpers.add_cache_buster(file, local)
+              else
+                BusterHelpers.add_cache_buster(file, local)
+              end
             end
           else
             path

--- a/lib/sinatra/assetpack/options.rb
+++ b/lib/sinatra/assetpack/options.rb
@@ -153,6 +153,7 @@ module Sinatra
       attrib :js_compression    # Symbol, compression method for JS
       attrib :css_compression   # Symbol, compression method for CSS
       attrib :output_path       # '/public'
+      attrib :host_name         # 'http://www.yourdomain.com'
 
       attrib :js_compression_options   # Hash
       attrib :css_compression_options  # Hash

--- a/lib/sinatra/assetpack/package.rb
+++ b/lib/sinatra/assetpack/package.rb
@@ -108,9 +108,17 @@ module Sinatra
     private
       def link_tag(file, options={})
         if js?
-          "<script src='#{e file}'#{kv options}></script>"
+          unless @assets.host_name.nil?
+            "<script src='#{@assets.host_name}#{e file}'#{kv options}></script>"
+          else
+            "<script src='#{e file}'#{kv options}></script>"
+          end
         elsif css?
-          "<link rel='stylesheet' href='#{e file}'#{kv options} />"
+          unless @assets.host_name.nil?
+            "<link rel='stylesheet' href='#{@assets.host_name}#{e file}'#{kv options} />"
+          else
+            "<link rel='stylesheet' href='#{e file}'#{kv options} />"
+          end
         end
       end
     end


### PR DESCRIPTION
1) This PR adds a "host_name" config variable to the main settings.

When set to a domain name, it will prepend JS and CSS tag sources with the specified domain name. It will also add the domain name to images specified in CSS files.

By specifying this option with an environment variable, assets can be accessed locally for development environments and accessed through a CDN in production environments. For instance: using assetpack in conjunction with the active_sync gem to deploy assets to an Amazon S3 bucket.

2) Also added a force UTF-8 console output. When running rake tasks, long filenames were being output as ASCII and the rake task would fail.
