### PR TITLE
Fix bug created by fix for files with dots in name

### DIFF
--- a/lib/sinatra/assetpack/options.rb
+++ b/lib/sinatra/assetpack/options.rb
@@ -247,7 +247,9 @@ module Sinatra
         # Remove cache-buster (/js/app.28389.js => /js/app)
         file = $1  if file =~ /^(.*)\.[0-9]+$/
 
-        Dir[File.join(app.root, from, "#{file}#{extension}")].first
+        matches = Dir[File.join(app.root, from, "#{file}.*")]
+        # Fix for filenames with dots (can't do this with glob)
+        matches.select { |f| f =~ /#{file}\.[^.]+$/ }.first
       end
 
       # Writes `public/#{path}` based on contents of `output`.


### PR DESCRIPTION
Hi, simple fix here for latest PR 23168869eeb0d58e020f70018b6b8526d6605015

I looked into git history and this seems to me like the proper way to fix the bug created.
