### PR TITLE
"Argument out of range" error on rake assetpack:build

### DIFF
--- a/lib/sinatra/assetpack/buster_helpers.rb
+++ b/lib/sinatra/assetpack/buster_helpers.rb
@@ -5,14 +5,14 @@ module Sinatra
       # Returns the cache buster suffix for given file(s).
       # This implementation somewhat obfuscates the mtime to not reveal deployment dates.
       def cache_buster_hash(*files)
-        i = mtime_for(files)
+        i = mtime_for(files).to_i
         (i * 4567).to_s.reverse[0...6]  if i
       end
 
       # Returns the maximum mtime for a given list of files.
       # It will return nil if none of them are found.
       def mtime_for(files)
-        files.map { |f| File.mtime(f).to_i  if f.is_a?(String) && File.file?(f) }.compact.max
+        files.map { |f| File.mtime(f)  if f.is_a?(String) && File.file?(f) }.compact.max
       end
 
       # Adds a cache buster for the given path.

--- a/lib/sinatra/assetpack/class_methods.rb
+++ b/lib/sinatra/assetpack/class_methods.rb
@@ -49,7 +49,7 @@ module Sinatra
 
             # Send headers
             content_type fmt.to_sym
-            last_modified File.mtime(fn).to_i
+            last_modified File.mtime(fn)
             expires 86400*30, :public
 
             format = File.extname(fn)[1..-1]


### PR DESCRIPTION
These changes fix the "argument out of range" error that occurs when
attempting to precompile the assets using the assetpack:build rake task.

The "Last-Modified" header value was being returned as a UNIX timestamp
which was breaking the Time.parse call used when saving the files.
