### PR TITLE
Add `js_compression :simple` which does not compress js

### DIFF
--- a/lib/sinatra/assetpack/engines/simple.rb
+++ b/lib/sinatra/assetpack/engines/simple.rb
@@ -5,7 +5,12 @@ module Sinatra::AssetPack
       str.gsub! %r{ *([;\{\},:]) *}, '\1'
       str
     end
+
+    def js(str, options={})
+      str
+    end
   end
 
   Compressor.register :css, :simple, SimpleEngine
+  Compressor.register :js,  :simple, SimpleEngine
 end

--- a/test/simplejs_test.rb
+++ b/test/simplejs_test.rb
@@ -1,0 +1,17 @@
+require File.expand_path('../test_helper', __FILE__)
+
+class SimplejsTest < UnitTest
+  setup do
+    app.set :reload_templates, true
+    app.assets.js_compression = :simple
+  end
+
+  teardown do
+    app.assets.js_compression  = :jsmin
+  end
+
+  test "build" do
+    get '/js/app.js'
+    assert body.include? ");\n\n$(function("
+  end
+end


### PR DESCRIPTION
Since `css_compression` has `:simple` option, `js_compression` should have it too.

NOTE: This patch with setting `js_compression :simple` will solve problems with invalid compression of bootstrap.js in production mode.
