### PR TITLE
Use the request.script_name as a path prefix.

### DIFF
--- a/lib/sinatra/assetpack/helpers.rb
+++ b/lib/sinatra/assetpack/helpers.rb
@@ -45,9 +45,9 @@ module Sinatra
         return ""  unless pack
 
         if settings.environment == :production
-          pack.to_production_html options
+          pack.to_production_html request.script_name, options
         else
-          pack.to_development_html options
+          pack.to_development_html request.script_name, options
         end
       end
 

--- a/lib/sinatra/assetpack/package.rb
+++ b/lib/sinatra/assetpack/package.rb
@@ -60,20 +60,31 @@ module Sinatra
         /^#{re}$/
       end
 
-      def to_development_html(options={})
+      def to_development_html(path_prefix, options={})
         paths_and_files.map { |path, file|
           path = add_cache_buster(path, file)
+          path = add_path_prefix(path, path_prefix)
           link_tag(path, options)
         }.join("\n")
       end
 
-      # The URI path of the minified file (with cache buster)
+      # The URI path of the minified file (with cache buster, but not a path prefix)
       def production_path
         add_cache_buster @path, *files
       end
 
-      def to_production_html(options={})
-        link_tag production_path, options
+      def to_production_html(path_prefix, options={})
+        path = production_path
+        path = add_path_prefix(path, path_prefix)
+        link_tag path, options
+      end
+
+      def add_path_prefix(path, path_prefix)
+        if path_prefix == '/'
+          path
+        else
+          "#{path_prefix}#{path}"
+        end
       end
 
       def minify

--- a/test/asset_host_test.rb
+++ b/test/asset_host_test.rb
@@ -34,12 +34,12 @@ class AssetHostTest < UnitTest
 
   test "host gets added to css source path" do
     app.stubs(:development?).returns(false)
-    assert TestApp.assets.packages['a.css'].to_production_html =~ %r{href='//cdn-[0|1].example.org/assets/a.[a-f0-9]{32}.css'}
+    assert TestApp.assets.packages['a.css'].to_production_html('/') =~ %r{href='//cdn-[0|1].example.org/assets/a.[a-f0-9]{32}.css'}
   end
 
   test "host gets added to js source path" do
     app.stubs(:development?).returns(false)
-    assert TestApp.assets.packages['b.js'].to_production_html =~ %r{src='//cdn-[0|1].example.org/assets/b.[a-f0-9]{32}.js'}
+    assert TestApp.assets.packages['b.js'].to_production_html('/') =~ %r{src='//cdn-[0|1].example.org/assets/b.[a-f0-9]{32}.js'}
   end
 
   test "host gets added to image helper path in production" do

--- a/test/subpath_test.rb
+++ b/test/subpath_test.rb
@@ -1,0 +1,26 @@
+require File.expand_path('../test_helper', __FILE__)
+
+# tests for running sinatra-assetpack with an application that's mounted under a
+# subdirectory
+class SubpathTest < UnitTest
+  def app
+    Rack::URLMap.new('/subpath' => Main)
+  end
+
+  test "helpers css (mounted on a subpath, development)" do
+    Main.settings.stubs(:environment).returns(:development)
+    get '/subpath/helpers/css'
+    assert body =~ %r{link rel='stylesheet' href='/subpath/css/screen.[a-f0-9]{32}.css' media='screen'}
+  end
+
+  test "helpers css (mounted on a subpath, production)" do
+    Main.settings.stubs(:environment).returns(:production)
+    get '/subpath/helpers/css'
+    assert body =~ %r{link rel='stylesheet' href='/subpath/css/application.[a-f0-9]{32}.css' media='screen'}
+  end
+
+  test '/subpath/js/hello.js (plain js)' do
+    get '/subpath/js/hello.js'
+    assert body == '$(function() { alert("Hello"); });'
+  end
+end


### PR DESCRIPTION
This allows sinatra-assetpack to be used in applications that are
mounted somewhere other than at the domain root without any
configuration specific to the application.

e.g. if you put this in the Gemfile

```
map '/subpath' do
  run AssetpackDemo::App
end
```

it will just work as expected.

Fixes #92.
