### PR TITLE
Cached files so they are only loaded once

### DIFF
--- a/lib/sinatra/assetpack/options.rb
+++ b/lib/sinatra/assetpack/options.rb
@@ -49,6 +49,8 @@ module Sinatra
         @js_compression  = :jsmin
         @css_compression = :simple
 
+        @reload_files_cache = true
+
         begin
           @output_path   = app.public
         rescue NoMethodError
@@ -82,12 +84,14 @@ module Sinatra
         return  unless File.directory?(File.join(app.root, options[:from]))
 
         @served[path] = options[:from]
+        @reload_files_cache = true
       end
 
       # Undo defaults.
       def reset!
         @served   = Hash.new
         @packages = Hash.new
+        @reload_files_cache = true
       end
 
       # Ignores a given path spec.
@@ -284,6 +288,8 @@ module Sinatra
 
       # Returns the files as a hash.
       def files(match=nil)
+          return @files unless @reload_files_cache
+
           # All
           # A buncha tuples
           tuples = @served.map { |prefix, local_path|
@@ -295,7 +301,9 @@ module Sinatra
             }
           }.flatten.compact
 
-          Hash[*tuples]
+          @reload_files_cache = false
+          @files = Hash[*tuples]
+          @files
       end
 
       # Returns an array of URI paths of those matching given globs.


### PR DESCRIPTION
`files` is an expensive method and is called a number of times. Added caching of the files result and reloads them in certain conditions

Before:

```
MethodProfiler results for: Sinatra::AssetPack::Package
+---------------------+------------+-------------+--------------+-------------+-------------+
| Method              | Min Time   | Max Time    | Average Time | Total Time  | Total Calls |
+---------------------+------------+-------------+--------------+-------------+-------------+
| #to_production_html | 643.064 ms | 2077.208 ms | 1247.375 ms  | 4989.499 ms | 4           |
| #production_path    | 641.064 ms | 2076.208 ms | 1246.374 ms  | 4985.498 ms | 4           |
| #files              | 640.064 ms | 2071.207 ms | 1243.624 ms  | 4974.497 ms | 4           |
| #paths_and_files    | 640.064 ms | 2071.207 ms | 1243.624 ms  | 4974.497 ms | 4           |
| #link_tag           | 0.000 ms   | 1.000 ms    | 0.500 ms     | 2.000 ms    | 4           |
| #add_path_prefix    | 0.000 ms   | 0.000 ms    | 0.000 ms     | 0.000 ms    | 4           |
| #css?               | 0.000 ms   | 0.000 ms    | 0.000 ms     | 0.000 ms    | 2           |
| #js?                | 0.000 ms   | 0.000 ms    | 0.000 ms     | 0.000 ms    | 4           |
+---------------------+------------+-------------+--------------+-------------+-------------+
MethodProfiler results for: Sinatra::AssetPack::Options
+-----------------+------------+-------------+--------------+-------------+-------------+
| Method          | Min Time   | Max Time    | Average Time | Total Time  | Total Calls |
+-----------------+------------+-------------+--------------+-------------+-------------+
| #glob           | 640.064 ms | 2070.207 ms | 1243.374 ms  | 4973.497 ms | 4           |
| #files          | 303.030 ms | 396.039 ms  | 331.433 ms   | 4971.497 ms | 15          |
| #ignored?       | 0.000 ms   | 1.000 ms    | 0.067 ms     | 1.000 ms    | 15          |
| #to_uri         | 0.000 ms   | 20.002 ms   | 0.018 ms     | 719.071 ms  | 39780       |
| #packages       | 0.000 ms   | 0.000 ms    | 0.000 ms     | 0.000 ms    | 4           |
| #served         | 0.000 ms   | 0.000 ms    | 0.000 ms     | 0.000 ms    | 4           |
| #app            | 0.000 ms   | 0.000 ms    | 0.000 ms     | 0.000 ms    | 8           |
| #local_file_for | 0.000 ms   | 0.000 ms    | 0.000 ms     | 0.000 ms    | 4           |
| #asset_hosts    | 0.000 ms   | 0.000 ms    | 0.000 ms     | 0.000 ms    | 8           |
+-----------------+------------+-------------+--------------+-------------+-------------+
MethodProfiler results for: Sinatra::AssetPack::BusterHelpers
+--------------------+----------+----------+--------------+------------+-------------+
| Method             | Min Time | Max Time | Average Time | Total Time | Total Calls |
+--------------------+----------+----------+--------------+------------+-------------+
| #cache_buster_hash | 0.000 ms | 5.001 ms | 1.250 ms     | 10.001 ms  | 8           |
| #add_cache_buster  | 0.000 ms | 5.001 ms | 1.250 ms     | 10.001 ms  | 8           |
+--------------------+----------+----------+--------------+------------+-------------+
```

After:

```
MethodProfiler results for: Sinatra::AssetPack::Package
+---------------------+----------+------------+--------------+------------+-------------+
| Method              | Min Time | Max Time   | Average Time | Total Time | Total Calls |
+---------------------+----------+------------+--------------+------------+-------------+
| #to_production_html | 4.000 ms | 369.037 ms | 102.010 ms   | 408.041 ms | 4           |
| #production_path    | 3.000 ms | 368.037 ms | 101.510 ms   | 406.041 ms | 4           |
| #files              | 0.000 ms | 362.037 ms | 91.009 ms    | 364.038 ms | 4           |
| #paths_and_files    | 0.000 ms | 362.037 ms | 91.009 ms    | 364.038 ms | 4           |
| #link_tag           | 0.000 ms | 1.000 ms   | 0.250 ms     | 1.000 ms   | 4           |
| #add_path_prefix    | 0.000 ms | 0.000 ms   | 0.000 ms     | 0.000 ms   | 4           |
| #css?               | 0.000 ms | 0.000 ms   | 0.000 ms     | 0.000 ms   | 2           |
| #js?                | 0.000 ms | 0.000 ms   | 0.000 ms     | 0.000 ms   | 4           |
+---------------------+----------+------------+--------------+------------+-------------+
MethodProfiler results for: Sinatra::AssetPack::Options
+-----------------+----------+------------+--------------+------------+-------------+
| Method          | Min Time | Max Time   | Average Time | Total Time | Total Calls |
+-----------------+----------+------------+--------------+------------+-------------+
| #glob           | 0.000 ms | 362.037 ms | 90.509 ms    | 362.037 ms | 4           |
| #files          | 0.000 ms | 361.037 ms | 24.069 ms    | 361.037 ms | 15          |
| #local_file_for | 0.000 ms | 1.000 ms   | 0.250 ms     | 1.000 ms   | 4           |
| #to_uri         | 0.000 ms | 1.001 ms   | 0.018 ms     | 47.003 ms  | 2652        |
| #ignored?       | 0.000 ms | 0.000 ms   | 0.000 ms     | 0.000 ms   | 15          |
| #served         | 0.000 ms | 0.000 ms   | 0.000 ms     | 0.000 ms   | 4           |
| #app            | 0.000 ms | 0.000 ms   | 0.000 ms     | 0.000 ms   | 8           |
| #packages       | 0.000 ms | 0.000 ms   | 0.000 ms     | 0.000 ms   | 4           |
| #asset_hosts    | 0.000 ms | 0.000 ms   | 0.000 ms     | 0.000 ms   | 8           |
+-----------------+----------+------------+--------------+------------+-------------+
MethodProfiler results for: Sinatra::AssetPack::BusterHelpers
+--------------------+----------+-----------+--------------+------------+-------------+
| Method             | Min Time | Max Time  | Average Time | Total Time | Total Calls |
+--------------------+----------+-----------+--------------+------------+-------------+
| #add_cache_buster  | 0.000 ms | 30.003 ms | 5.125 ms     | 41.003 ms  | 8           |
| #cache_buster_hash | 0.000 ms | 29.003 ms | 4.875 ms     | 39.003 ms  | 8           |
+--------------------+----------+-----------+--------------+------------+-------------+
```

Helps towards solving #85
