### PR TITLE
relax backports from ruby 1.9+ bundle

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,6 @@ PATH
   remote: .
   specs:
     sinatra-assetpack (0.2.5)
-      backports
       jsmin
       rack-test
       sinatra
@@ -16,7 +15,6 @@ GEM
       open4
     Platform (0.4.0)
     awesome_print (1.1.0)
-    backports (3.3.1)
     coffee-script (2.2.0)
       coffee-script-source
       execjs

--- a/lib/sinatra/assetpack.rb
+++ b/lib/sinatra/assetpack.rb
@@ -1,5 +1,4 @@
 require 'rack/test'
-require 'backports' if RUBY_VERSION < "1.9"
 
 module Sinatra
   module AssetPack

--- a/lib/sinatra/assetpack/options.rb
+++ b/lib/sinatra/assetpack/options.rb
@@ -234,7 +234,7 @@ module Sinatra
         matches = Dir[File.join(expand_from(from), "#{file}.*")]
 
         # Fix for filenames with dots (can't do this with glob)
-        matches.select! { |f| f =~ /#{file}\.[^.]+$/ }
+        matches = matches.select { |f| f =~ /#{file}\.[^.]+$/ }
 
         # Sort static file match, weighting exact file extension matches
         matches.sort! do |f, _|

--- a/sinatra-assetpack.gemspec
+++ b/sinatra-assetpack.gemspec
@@ -14,7 +14,6 @@ Gem::Specification.new do |s|
   s.cert_chain  = ['certs/j15e.pem']
   s.signing_key = File.expand_path('~/.gem/private_key.pem') if $0 =~ /gem\z/
 
-  s.add_dependency 'backports'
   s.add_dependency 'jsmin'
   s.add_dependency 'rack-test'
   s.add_dependency 'sinatra'


### PR DESCRIPTION
The backports gem is not needed in sinatra-assetpack if ruby version is 1.9+. Please, do not bloat application runtime bundle.
