### PR TITLE
Adds ability to disable automatic image dimension application to <img> elements.

### DIFF
--- a/lib/sinatra/assetpack/helpers.rb
+++ b/lib/sinatra/assetpack/helpers.rb
@@ -18,7 +18,7 @@ module Sinatra
 
           attrs[:src] = HtmlHelpers.get_file_uri(src, settings.assets)
 
-          if i.dimensions?
+          if settings.assets.image_dimensions && i.dimensions?
             attrs[:width]  ||= i.width
             attrs[:height] ||= i.height
           end

--- a/lib/sinatra/assetpack/options.rb
+++ b/lib/sinatra/assetpack/options.rb
@@ -50,6 +50,7 @@ module Sinatra
         @js_compression  = :jsmin
         @css_compression = :simple
         @reload_files_cache = true
+        @image_dimensions = true
 
         begin
           @output_path   = app.public
@@ -166,8 +167,9 @@ module Sinatra
       attrib :js_compression_options   # Hash
       attrib :css_compression_options  # Hash
 
-      attrib :prebuild          # Bool
+      attrib :prebuild             # Bool
       attrib :cache_dynamic_assets # Bool
+      attrib :image_dimensions     # Bool
 
       def expires(*args)
         if args.empty?

--- a/test/helpers_test.rb
+++ b/test/helpers_test.rb
@@ -30,6 +30,16 @@ class HelpersTest < UnitTest
     assert body =~ %r{height='16'}
   end
 
+  test "img without dimensions existing" do
+    app.stubs(:development?).returns(true)
+    app.assets.stubs(:image_dimensions).returns(false)
+    get '/helper/email'
+
+    assert body =~ %r{src='/images/email.png'}
+    assert !(body =~ %r{width='16'})
+    assert !(body =~ %r{height='16'})
+  end
+
   test "css" do
     re = Array.new
     get '/helper/css/app'; re << body


### PR DESCRIPTION
We're experiencing issues with our responsive design implementation when images have explicit widths are applied to them. This is also an issue when serving 2x images for high-density displays. Typically, we want images to simply take up only the space that they are provided since they'll likely be in a flexible container.

Normally this works fine, but IE8 in particular is having issues with `max-width: 100%` and `height: auto` on images that have an explicit width.

This PR allows you to disable that functionality.
