### PR TITLE
Correctly handle empty list of engines in Tilt.mappings

### DIFF
--- a/lib/sinatra/assetpack.rb
+++ b/lib/sinatra/assetpack.rb
@@ -17,6 +17,7 @@ module Sinatra
       @formats ||= begin
         hash = Hash.new
         Tilt.mappings.each do |format, (engine, _)|
+          next if engine.nil?
           case engine.default_mime_type
           when 'text/css' then hash[format] = 'css'
           when 'application/javascript' then hash[format] = 'js'

--- a/test/tilt_test.rb
+++ b/test/tilt_test.rb
@@ -2,6 +2,10 @@ require File.expand_path('../test_helper', __FILE__)
 
 class OptionsTest < UnitTest
   test "tilt mappings" do
+    # trigger Tilt issue 206 then reset formats
+    assert_nil Tilt["hello.world"]		
+    Sinatra::AssetPack.instance_variable_set :@formats, nil
+    # extract formats
     @formats = Sinatra::AssetPack.tilt_formats
     assert @formats['sass'] == 'css'
     assert @formats['scss'] == 'css'


### PR DESCRIPTION
The implementation of `AssetPack.tilt_formats` currently assumes there is always at least one engine registered for a given Tilt format, but that is not always the case (related: https://github.com/rtomayko/tilt/pull/206)

This patch skips over formats that don't have an engine instead of calling methods on `nil`.
