### PR TITLE
Add filename option to render so templates can have access.

### DIFF
--- a/lib/sinatra/assetpack/class_methods.rb
+++ b/lib/sinatra/assetpack/class_methods.rb
@@ -87,7 +87,7 @@ module Sinatra
 
               @template_cache.fetch(fn) {
                 settings.assets.fetch_dynamic_asset(fn) {
-                  out = render format.to_sym, File.read(fn)
+                  out = render format.to_sym, File.read(fn), :filename => fn
                   out = asset_filter_css(out)  if fmt == 'css'
                   out
                 }


### PR DESCRIPTION
In Sinatra, the file argument passed to a Tilt Template is usually a path to the calling Ruby file, not the name of the template file. This makes it impossible to reuse the filename when outputting the compiled template. For example, when precompiling Handlebars templates it would be nice to be able to automatically namespace them in JavaScript based on their filename. This change adds an option to pass the filename.
