### PR TITLE
Stop local_file_for from modifying param in place

### DIFF
--- a/lib/sinatra/assetpack/options.rb
+++ b/lib/sinatra/assetpack/options.rb
@@ -216,7 +216,7 @@ module Sinatra
       # Returns the local file for a given URI path.
       # Returns nil if a file is not found.
       def local_file_for(request)
-        request.squeeze!('/')
+        request = request.squeeze('/')
         serve_path, from = served.detect { |path, _| request.start_with?(path) }
 
         return if !from

--- a/test/local_file_test.rb
+++ b/test/local_file_test.rb
@@ -32,4 +32,13 @@ class LocalFileTest < UnitTest
     fn = App.assets.local_file_for '/images/404.jpg'
     assert fn.nil?
   end
+
+  test "local file for (with remote url)" do
+    url  = 'http://example.com/images/200.jpg'
+    copy = url.dup
+    fn   = App.assets.local_file_for copy
+    assert fn.nil?
+    assert_equal url, copy
+  end
+
 end


### PR DESCRIPTION
I find squeeze! to be unexpected here (in calling methods named without !), and it looks like it might not be needed.

Specifically, I'd like to be able to use img() in a generic image_tag helper, without having to fork for local and remote assets. This change allows that, since if the local file isn't found, the original src is used.
