### PR TITLE
Provide template filename to Sinatra/Tile via settings.assets

### DIFF
--- a/lib/sinatra/assetpack/class_methods.rb
+++ b/lib/sinatra/assetpack/class_methods.rb
@@ -87,7 +87,8 @@ module Sinatra
 
               @template_cache.fetch(fn) {
                 settings.assets.fetch_dynamic_asset(fn) {
-                  out = render format.to_sym, File.read(fn), :filename => fn
+                  settings.templates[fn.to_sym] = [Proc.new { File.read(fn) }, fn]
+                  out = render format.to_sym, fn.to_sym, :filename => fn
                   out = asset_filter_css(out)  if fmt == 'css'
                   out
                 }


### PR DESCRIPTION
Compilation errors for dynamic templates always show `class_methods.rb` as the filename. This is because the `filename` option passed to `render` is never used (presumably it used to work, but it no longer does).

However per the commits below, it is possible to supply the template filename via `settings.templates`. This is something of an abuse of the intent of `settings.templates`, but given the benefit of showing the correct error information I think it's worth it.
