### PR TITLE
Account for suburi in img helper

### DIFF
--- a/lib/sinatra/assetpack/helpers.rb
+++ b/lib/sinatra/assetpack/helpers.rb
@@ -10,7 +10,10 @@ module Sinatra
       end
 
       def img(src, options={})
-        attrs = { :src => HtmlHelpers.get_file_uri(src, settings.assets) }
+        file_path = HtmlHelpers.get_file_uri(src, settings.assets)
+        file_path = File.join(request.script_name, file_path)
+
+        attrs = { :src => file_path }
         attrs = attrs.merge(options)
 
         "<img#{HtmlHelpers.kv attrs} />"

--- a/test/app/app.rb
+++ b/test/app/app.rb
@@ -76,5 +76,11 @@ class Main < Sinatra::Base
       != css :application, :media => 'screen'
     }.strip
   end
+
+  get '/helpers/email' do
+    haml %{
+      != img '/images/email.png'
+    }.strip
+  end
 end
 

--- a/test/subpath_test.rb
+++ b/test/subpath_test.rb
@@ -19,6 +19,18 @@ class SubpathTest < UnitTest
     assert body =~ %r{link rel='stylesheet' href='/subpath/css/application.[a-f0-9]{32}.css' media='screen'}
   end
 
+  test "helpers img (mounted on a subpath, development)" do
+    Main.settings.stubs(:environment).returns(:development)
+    get '/subpath/helpers/email'
+    assert body =~ %r{src='/subpath/images/email.png'}
+  end
+
+  test "helpers img (mounted on a subpath, production)" do
+    Main.settings.stubs(:environment).returns(:production)
+    get '/subpath/helpers/email'
+    assert body =~ %r{src='/subpath/images/email.[a-f0-9]{32}.png'}
+  end
+
   test '/subpath/js/hello.js (plain js)' do
     get '/subpath/js/hello.js'
     assert body == '$(function() { alert("Hello"); });'


### PR DESCRIPTION
Currently, the `img` helper does not prepend the suburi to the generated image tag output (see #136). For example,

```
!= img '/images/foo.png'
```

will output

```
<img src='/images/foo.<cache-buster>.png' />
```

This is a problem when the app is deployed to a suburi in production. My thought is the `img` helper should behave similarly to the `js` and `css` helper by prepending the suburi to the generated html output.
