### PR TITLE
image_path helper

### DIFF
--- a/lib/sinatra/assetpack/helpers.rb
+++ b/lib/sinatra/assetpack/helpers.rb
@@ -10,13 +10,15 @@ module Sinatra
       end
 
       def img(src, options={})
-        file_path = HtmlHelpers.get_file_uri(src, settings.assets)
-        file_path = File.join(request.script_name, file_path)
-
-        attrs = { :src => file_path }
+        attrs = { :src => image_path(src) }
         attrs = attrs.merge(options)
 
         "<img#{HtmlHelpers.kv attrs} />"
+      end
+
+      def image_path(src)
+        file_path = HtmlHelpers.get_file_uri(src, settings.assets)
+        File.join(request.script_name, file_path)
       end
 
       def show_asset_pack(type, *args)

--- a/test/helpers_test.rb
+++ b/test/helpers_test.rb
@@ -6,6 +6,8 @@ class HelpersTest < UnitTest
   Main.get('/helper/css/all') { css :application, :sq }
   Main.get('/helper/css/app') { css :application }
   Main.get('/helper/css/sq') { css :sq }
+  Main.get('/helper/foo_path') { image_path '/images/foo.jpg' }
+  Main.get('/helper/email_path') { image_path '/images/email.png' }
 
   test "img non-existing" do
     get '/helper/foo'
@@ -24,6 +26,26 @@ class HelpersTest < UnitTest
     get '/helper/email'
 
     assert body =~ %r{src='/images/email.[a-f0-9]{32}.png'}
+  end
+
+  test "image_path non-existing" do
+    get '/helper/foo_path'
+
+    assert body == "/images/foo.jpg"
+  end
+
+  test "image_path existing (development)" do
+    app.stubs(:development?).returns(true)
+    get '/helper/email_path'
+
+    assert body == "/images/email.png"
+  end
+
+  test "image_path existing (production)" do
+    app.stubs(:development?).returns(false)
+    get '/helper/email_path'
+
+    assert body =~ %r{\A/images/email.[a-f0-9]{32}.png\z}
   end
 
   test "css" do


### PR DESCRIPTION
This PR adds a helper method (`image_path`) to get the path for an image, as `img` generated a complete `<img ... />` tag and you might want to use the path for something else (e.g., a favicon, which is my case).
