### PR TITLE
No broken HTML for crazy file names

### DIFF
--- a/lib/sinatra/assetpack/package.rb
+++ b/lib/sinatra/assetpack/package.rb
@@ -124,9 +124,9 @@ module Sinatra
         file_path = HtmlHelpers.get_file_uri(file, @assets)
 
         if js?
-          "<script src='#{file_path}'#{kv options}></script>"
+          "<script src='#{e file_path}'#{kv options}></script>"
         elsif css?
-          "<link rel='stylesheet' href='#{file_path}'#{kv options} />"
+          "<link rel='stylesheet' href='#{e file_path}'#{kv options} />"
         end
       end
     end


### PR DESCRIPTION
Fix the problem that `js` and `css` methods generate corrupt HTML when you have a file named such as `foobar'>.css`.
