### PR TITLE
Skip CSS preprocessing for malformed URIs 

### DIFF
--- a/lib/sinatra/assetpack/css.rb
+++ b/lib/sinatra/assetpack/css.rb
@@ -5,7 +5,13 @@ module Sinatra
     module Css
       def self.preproc(source, assets)
         source.gsub(/url\((["']?)(.*?)(["']?)\)/) do |match|
-          uri = URI.parse($2)
+
+          # Not parsable by URI.parse
+          begin
+            uri = URI.parse($2)
+          rescue URI::InvalidURIError
+            next match
+          end
 
           # Not a valid complete url
           next match if uri.path.nil?

--- a/test/app/app/css/bad_uri.scss
+++ b/test/app/app/css/bad_uri.scss
@@ -1,0 +1,3 @@
+form {
+  background-image: url('data:image/svg+xml;base64, PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZlcnNpb249IjEuMSIgeD0iMHB4IiB5PSIwcHgiIHdpZHRoPSI2cHgiIGhlaWdodD0iM3B4IiB2aWV3Qm94PSIwIDAgNiAzIiBlbmFibGUtYmFja2dyb3VuZD0ibmV3IDAgMCA2IDMiIHhtbDpzcGFjZT0icHJlc2VydmUiPjxwb2x5Z29uIHBvaW50cz0iNS45OTIsMCAyLjk5MiwzIC0wLjAwOCwwICIvPjwvc3ZnPg==');
+  }

--- a/test/preproc_test.rb
+++ b/test/preproc_test.rb
@@ -42,9 +42,17 @@ class PreprocTest < UnitTest
   end
 
   test "ignores data-uris" do
-    app.stubs(:clear_cach).returns(true)
+    app.stubs(:clear_cache).returns(true)
     app.stubs(:development?).returns(false)
     get '/css/bariol.css'
     assert body =~ %r{data:application/x-font-woff;charset=utf-8;base64,[A-Za-z0-9=/]{100,}}
+  end
+
+  test "skips malformed data-uris" do
+    app.stubs(:clear_cache).returns(true)
+    app.stubs(:development?).returns(false)
+    get '/css/bad_uri.css'
+    puts body
+    assert body =~ %r{data:image/svg\+xml;base64, PHN2ZyB4bW}
   end
 end


### PR DESCRIPTION
The regex in css.rb that checks for URLs (for cache busting?) will match
some URLs that URI.parse considers invalid. This came up with a file
from zurb/foundation that contained a space in a data:image URI. SASS
and browsers seem to handle the space fine, but URI.parse throws an
InvalidURIError.

My solution was to wrap the call and return the match unchanged if
InvalidURIError is thrown. Another solution might be to change '(._?)'
in the regex to '(\S_?)', but that would only fix the issue with
whitespace--it seems preferable to just pass any string that URI.parse
can't handle unchanged, then catch it in SASS if it's actually going to
cause a problem.

Pull request #152 attempts to fix the same issue, but would skip
anything where the url starts with "data:", which doesn't seem like what
we want to do.

I've also added tests to preproc_test.rb for the fix, and a bad_uri.scss
file that contains data that shows the issue.
