### PR TITLE
Updates dependent require calls on invocation

### DIFF
--- a/lib/sinatra/assetpack.rb
+++ b/lib/sinatra/assetpack.rb
@@ -1,4 +1,5 @@
 require 'rack/test'
+require 'sinatra'
 
 module Sinatra
   module AssetPack


### PR DESCRIPTION
Without a `require 'sinatra'` in this spot, `Sinatra::AssetPack` must be loaded in a Gemfile after Sinatra is already loaded in order to work. Otherwise, it will generate problems:

```
NoMethodError: undefined method `register' for Sinatra:Module
...src/projects/uphex/uphex-pulse/.gem/ruby/2.1.0/gems/sinatra-assetpack-0.3.2/lib/sinatra/assetpack.rb:70:in `<module:Sinatra>'
...src/projects/uphex/uphex-pulse/.gem/ruby/2.1.0/gems/sinatra-assetpack-0.3.2/lib/sinatra/assetpack.rb:4:in `<top (required)>'
```

Since `Sinatra::AssetPack` depends on Sinatra, it needs to use that dependency here or else it is vulnerable to this sort of breakage.
