### PR TITLE
Prevent syntax error in regex

### DIFF
--- a/lib/sinatra/assetpack/package.rb
+++ b/lib/sinatra/assetpack/package.rb
@@ -108,7 +108,7 @@ module Sinatra
         paths.map { |path|
           result = session.get(path)
           if result.body.respond_to?(:force_encoding)
-            response_encoding = result.content_type.split(/;\s*charset\s*=\s*/).last.upcase rescue 'ASCII-8BIT'
+            response_encoding = result.content_type.split(/\;\s*charset\s*=\s*/).last.upcase rescue 'ASCII-8BIT'
             result.body.force_encoding(response_encoding).encode(Encoding.default_external || 'ASCII-8BIT')  if result.status == 200
           else
             result.body  if result.status == 200


### PR DESCRIPTION
Running ruby 1.9.3-p448 this regex was giving me:

```
SyntaxError Exception: unterminated regexp meets end of file
```

Escaping the semicolon fixes the issue.

Debugger output:

```
[107, 116] in /Users/nsalisbury/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/sinatra-assetpack-0.3.3/lib/sinatra/assetpack/package.rb
   107          session = Rack::Test::Session.new(@assets.app)
   108          paths.map { |path|
   109            result = session.get(path)
   110            if result.body.respond_to?(:force_encoding)
   111              require 'ruby-debug'; debugger
=> 112              response_encoding = result.content_type.split(/;\s*charset\s*=\s*/).last.upcase rescue 'ASCII-8BIT'
   113              result.body.force_encoding(response_encoding).encode(Encoding.default_external || 'ASCII-8BIT')  if result.status == 200
   114            else
   115              result.body  if result.status == 200
   116            end
(rdb:1) result.content_type
"application/javascript;charset=utf-8"
(rdb:1) result.content_type.split(/;\s*charset\s*=\s*/)
*** SyntaxError Exception: /Users/nsalisbury/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/sinatra-assetpack-0.3.3/lib/sinatra/assetpack/package.rb:113: unterminated regexp meets end of file
/Users/nsalisbury/.rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/sinatra-assetpack-0.3.3/lib/sinatra/assetpack/package.rb:113: syntax error, unexpected $end, expecting ')'
result.content_type.split(/
                           ^

(rdb:1) result.content_type.split(/\;\s*charset\s*=\s*/)
["application/javascript", "utf-8"]
```
