### PR TITLE
added compress_environments setting

### DIFF
--- a/lib/sinatra/assetpack/helpers.rb
+++ b/lib/sinatra/assetpack/helpers.rb
@@ -38,7 +38,7 @@ module Sinatra
         pack = settings.assets.packages["#{name}.#{type}"]
         return ""  unless pack
 
-        if settings.environment == :production
+        if settings.assets.compress_environments.member? settings.environment
           pack.to_production_html request.script_name, options
         else
           pack.to_development_html request.script_name, options

--- a/lib/sinatra/assetpack/options.rb
+++ b/lib/sinatra/assetpack/options.rb
@@ -63,6 +63,8 @@ module Sinatra
         @css_compression_options = Hash.new
         @dynamic_asset_cache     = Hash.new
 
+        @compress_environments   = [:production]
+
         @ignored = Array.new
 
         reset!
@@ -169,7 +171,9 @@ module Sinatra
       attrib :output_path       # '/public'
       attrib :asset_hosts       # [ 'http://cdn0.example.org', 'http://cdn1.example.org' ]
 
-      attrib :js_compression_options   # Hash
+      attrib :compress_environments # [ :production ]
+
+      attrib :js_compression_options  # Hash
       attrib :css_compression_options  # Hash
 
       attrib :prebuild          # Bool
@@ -193,6 +197,11 @@ module Sinatra
         @css_compression = name unless name.nil?
         @css_compression_options = options if options.is_a?(Hash)
         @css_compression
+      end
+
+      def compress_environments(*args)
+        @compress_environments = args unless args.empty?
+        @compress_environments
       end
 
       # =====================================================================

--- a/test/subpath_test.rb
+++ b/test/subpath_test.rb
@@ -14,6 +14,7 @@ class SubpathTest < UnitTest
   end
 
   test "helpers css (mounted on a subpath, production)" do
+    Main.settings.assets.stubs(:compress_environments).returns([:production, :staging])
     Main.settings.stubs(:environment).returns(:production)
     get '/subpath/helpers/css'
     assert body =~ %r{link rel='stylesheet' href='/subpath/css/application.[a-f0-9]{32}.css' media='screen'}

--- a/test/unit_test.rb
+++ b/test/unit_test.rb
@@ -76,10 +76,18 @@ class AppTest < UnitTest
   end
 
   test "helpers in production (compressed html thingie)" do
+    app.settings.assets.stubs(:compress_environments).returns([:production])
     app.settings.stubs(:environment).returns(:production)
     get '/index.html'
     assert body =~ /<script src='\/js\/app.[a-f0-9]{32}.js'><\/script>/
   end
+
+   test "helpers in staging with custom compression envs (compressed html thingie)" do
+     app.settings.assets.stubs(:compress_environments).returns([:production, :staging])
+     app.settings.stubs(:environment).returns(:staging)
+     get '/index.html'
+     assert body =~ /<script src='\/js\/app.[a-f0-9]{32}.js'><\/script>/
+   end
 
   test "file with multiple dots in name" do
     get '/js/lib-3.2.1.min.js'
@@ -108,13 +116,22 @@ class AppTest < UnitTest
   end
 
   test "helpers css (development)" do
+    app.settings.stubs(:compress_environments).returns([:production])
     app.settings.stubs(:environment).returns(:development)
     get '/helpers/css'
     assert body =~ %r{link rel='stylesheet' href='/css/screen.[a-f0-9]{32}.css' media='screen'}
   end
 
   test "helpers css (production)" do
+    app.settings.assets.stubs(:compress_environments).returns([:production])
     app.settings.stubs(:environment).returns(:production)
+    get '/helpers/css'
+    assert body =~ %r{link rel='stylesheet' href='/css/application.[a-f0-9]{32}.css' media='screen'}
+  end
+
+  test "helpers css (staging, with custom compress_environments)" do
+    app.settings.assets.stubs(:compress_environments).returns([:production, :staging])
+    app.settings.stubs(:environment).returns(:staging)
     get '/helpers/css'
     assert body =~ %r{link rel='stylesheet' href='/css/application.[a-f0-9]{32}.css' media='screen'}
   end


### PR DESCRIPTION
Allows you to use compression (concatenation) on static assets
in RACK_ENVs other than production (e.g. staging)

I didn't see the docs in the repository, so I didn't update them. If you point me to where they're stored I can send a PR for that too :)