### PR TITLE
avoid 30 css links limit on MS internet-explorers

### DIFF
--- a/lib/sinatra/assetpack/package.rb
+++ b/lib/sinatra/assetpack/package.rb
@@ -61,11 +61,29 @@ module Sinatra
       end
 
       def to_development_html(path_prefix, options={})
-        paths_and_files.map { |path, file|
-          path = add_cache_buster(path, file)
-          path = add_path_prefix(path, path_prefix)
-          link_tag(path, options)
-        }.join("\n")
+        if js?
+          return paths_and_files.map { |path, file|
+            path = add_cache_buster(path, file)
+            path = add_path_prefix(path, path_prefix)
+            link_tag(path, options)
+          }.join("\n")
+        else # see http://stackoverflow.com/questions/9906794/internet-explorers-css-rules-limits 
+          list = paths_and_files.map { |path, file|
+            path = add_cache_buster(path, file)
+            add_path_prefix(path, path_prefix)
+          }
+
+          styles = []
+          list.each_slice(31).to_a.each do|link_group|
+            style = ['<style>']
+            link_group.each do|css_path|
+              style.push("@import \'#{css_path}\';\n")
+            end
+            style.push('</style>')
+            styles.push(style.join(''))
+          end
+          styles.join('')
+        end
       end
 
       # The URI path of the minified file (with cache buster, but not a path prefix)

--- a/test/helpers_test.rb
+++ b/test/helpers_test.rb
@@ -54,6 +54,6 @@ class HelpersTest < UnitTest
     get '/helper/css/sq';  re << body
 
     get '/helper/css/all'
-    assert body.gsub(/[\r\n]*/m, '') == re.join('')
+    assert body.gsub(/[\r\n]*/m, '') == re.join('').gsub(/[\r\n]*/m, '')
   end
 end

--- a/test/subpath_test.rb
+++ b/test/subpath_test.rb
@@ -10,7 +10,7 @@ class SubpathTest < UnitTest
   test "helpers css (mounted on a subpath, development)" do
     Main.settings.stubs(:environment).returns(:development)
     get '/subpath/helpers/css'
-    assert body =~ %r{link rel='stylesheet' href='/subpath/css/screen.[a-f0-9]{32}.css' media='screen'}
+    assert body =~ %r{<style>@import '/subpath/css/screen.e99ac62b0b383ea8ffd371a5aa87744d.css';\n</style>}
   end
 
   test "helpers css (mounted on a subpath, production)" do

--- a/test/unit_test.rb
+++ b/test/unit_test.rb
@@ -110,7 +110,7 @@ class AppTest < UnitTest
   test "helpers css (development)" do
     app.settings.stubs(:environment).returns(:development)
     get '/helpers/css'
-    assert body =~ %r{link rel='stylesheet' href='/css/screen.[a-f0-9]{32}.css' media='screen'}
+    assert body =~ %r{<style>@import '/css/screen.[a-f0-9]{32}.css';\n</style>}
   end
 
   test "helpers css (production)" do


### PR DESCRIPTION
IE loads only 30 css links, see
http://blogs.msdn.com/b/ieinternals/archive/2011/05/14/10164546.aspx and the demo http://demos.telerik.com/testcases/BrokenTheme.aspx

My solution is slice the css links by 31, use a `<style>` tag to `@import` the 31 css files.