### PR TITLE
Read files with utf-8 encoding

### DIFF
--- a/lib/sinatra/assetpack/class_methods.rb
+++ b/lib/sinatra/assetpack/class_methods.rb
@@ -76,7 +76,7 @@ module Sinatra
               if fmt == 'css'
                 # Matching static file format
                 pass unless fmt == File.extname(fn)[1..-1]
-                @template_cache.fetch(fn) { asset_filter_css File.read(fn) }
+                @template_cache.fetch(fn) { asset_filter_css File.open(fn, "r:utf-8", &:read) }
               else
                 # It's a raw file, just send it
                 send_file fn
@@ -87,7 +87,7 @@ module Sinatra
 
               @template_cache.fetch(fn) {
                 settings.assets.fetch_dynamic_asset(fn) {
-                  out = render format.to_sym, File.read(fn), :filename => fn
+                  out = render format.to_sym, File.open(fn, "r:utf-8", &:read), :filename => fn
                   out = asset_filter_css(out)  if fmt == 'css'
                   out
                 }

--- a/lib/sinatra/assetpack/css.rb
+++ b/lib/sinatra/assetpack/css.rb
@@ -39,7 +39,7 @@ module Sinatra
       def self.build_data_uri(file)
         require 'base64'
 
-        data = File.read(file)
+        data = File.open(file, "r:utf-8", &:read)
         ext  = File.extname(file)
         mime = Sinatra::Base.mime_type(ext)
         b64  = Base64.encode64(data).gsub("\n", '')


### PR DESCRIPTION
If css file contain some non ascii characters it will fail with exception

For example it fail on https://github.com/dbushell/Pikaday/blob/master/css/pikaday.css (`©` is not ascii)

This commit read all files in utf-8 encoding
