### PR TITLE
This allows for users to set the environment as a string 

### DIFF
--- a/lib/sinatra/assetpack/helpers.rb
+++ b/lib/sinatra/assetpack/helpers.rb
@@ -43,7 +43,7 @@ module Sinatra
         pack = settings.assets.packages["#{name}.#{type}"]
         return ""  unless pack
 
-        if settings.environment == :production
+        if settings.environment.to_sym == :production
           pack.to_production_html request.script_name, options
         else
           pack.to_development_html request.script_name, options


### PR DESCRIPTION
This allows for users to set the environment as a string , often code uses string environment names and not symbols , this would wourk just as well with either without much effort